### PR TITLE
Remover php 7.0 no UbuntuPHPS

### DIFF
--- a/ubuntu-PHPS/Dockerfile
+++ b/ubuntu-PHPS/Dockerfile
@@ -15,7 +15,6 @@ RUN LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php
 #INSTALL PHP VERSIONS
 RUN apt-get update && apt-get upgrade -y
 RUN apt -y install php5.6
-RUN apt -y install php7.0
 RUN apt -y install php7.1
 RUN apt -y install php7.2
 
@@ -28,16 +27,6 @@ RUN apt-get -y install php5.6-pgsql
 RUN apt-get -y install php5.6-imagick
 RUN apt-get -y install php5.6-mcrypt
 RUN apt-get -y install php5.6-zip
-
-#INSTALL PHP7.0 PACKAGES
-RUN apt-get -y install php7.0-mbstring
-RUN apt-get -y install php7.0-xml
-RUN apt-get -y install php7.0-curl
-RUN apt-get -y install php7.0-mysql
-RUN apt-get -y install php7.0-pgsql
-RUN apt-get -y install php7.0-imagick
-RUN apt-get -y install php7.0-mcrypt
-RUN apt-get -y install php7.0-zip
 
 #INSTALL PHP7.1 PACKAGES
 RUN apt-get -y install php7.1-mbstring
@@ -81,15 +70,15 @@ RUN npm install -g npm@latest
 RUN n 8.*
 
 #SELECTPHP SCRIPT
-ADD selectphp.sh /usr/local/bin/selectphp
+ADD https://gist.githubusercontent.com/esron/7857d0d6d7fe516639aa4be65635bb32/raw/48499b1fc9151666f5d95ad333d224796563a99e/selectphp.sh /usr/local/bin/selectphp
 RUN cd /usr/local/bin/ && chmod +x selectphp
 
 #APACHELINKER SCRIPT
-ADD apachelinker.sh /usr/local/bin/apachelinker
+ADD https://gist.githubusercontent.com/esron/7857d0d6d7fe516639aa4be65635bb32/raw/48499b1fc9151666f5d95ad333d224796563a99e/apachelinker.sh /usr/local/bin/apachelinker
 RUN cd /usr/local/bin/ && chmod +x apachelinker
 
 # APACHE CONFIG
 RUN a2enmod rewrite
-ADD apache.conf /etc/apache2/sites-enabled/000-default.conf
+ADD https://gist.githubusercontent.com/esron/7857d0d6d7fe516639aa4be65635bb32/raw/48499b1fc9151666f5d95ad333d224796563a99e/apache.conf /etc/apache2/sites-enabled/000-default.conf
 
 WORKDIR /

--- a/ubuntu-PHPS/Dockerfile
+++ b/ubuntu-PHPS/Dockerfile
@@ -1,6 +1,6 @@
-from lissonpsantos2/ubuntu-16.04-basic:latest
+FROM lissonpsantos2/ubuntu-16.04-basic:latest
 
-MAINTAINER Alisson Pereira dos Santos <lissonpsantos2@gmail.com>, Esron Silva <esron.dtamar@gmail.com>
+LABEL authors="Alisson Pereira dos Santos <lissonpsantos2@gmail.com>, Esron Silva <esron.dtamar@gmail.com>"
 
 #IMAGE VARIABLES
 ENV PROJECT_FOLDER /home/project-folder

--- a/ubuntu-PHPS/selectphp.sh
+++ b/ubuntu-PHPS/selectphp.sh
@@ -5,7 +5,6 @@ SELECTED=$1
 if [ "$SELECTED" = "7.2" ]; then
   update-alternatives --set php /usr/bin/php7.2
   a2dismod php7.1
-  a2dismod php7.0
   a2dismod php5.6
   a2enmod php7.2
   service apache2 restart
@@ -16,7 +15,6 @@ fi
 if [ "$SELECTED" = "7.1" ]; then
   update-alternatives --set php /usr/bin/php7.1
   a2dismod php7.2
-  a2dismod php7.0
   a2dismod php5.6
   a2enmod php7.1
   service apache2 restart
@@ -24,22 +22,10 @@ if [ "$SELECTED" = "7.1" ]; then
   exit 0
 fi
 
-if [ "$SELECTED" = "7.0" ]; then
-  update-alternatives --set php /usr/bin/php7.0
-  a2dismod php7.2
-  a2dismod php7.1
-  a2dismod php5.6
-  a2enmod php7.0
-  service apache2 restart
-	echo "PHP 7.0 ACTIVATED!"
-  exit 0
-fi
-
 if [ "$SELECTED" = "5.6" ]; then
   update-alternatives --set php /usr/bin/php5.6
   a2dismod php7.2
   a2dismod php7.1
-  a2dismod php7.0
   a2enmod php5.6
   service apache2 restart
 	echo "PHP 5.6 ACTIVATED!"


### PR DESCRIPTION
This merge resolve #6 

Inclui download de scripts via gist, dessa forma os arquivos de scripts podem ficar separados do repositório o que facilita os testes.